### PR TITLE
fix: use english version of oeaw privacy statement

### DIFF
--- a/api/data/de.html
+++ b/api/data/de.html
@@ -6,7 +6,7 @@
         Juristische Person öffentlichen Rechts (BGBl 569/1921 idF BGBl I 130/2003)<br/>
         <a href="https://acdh.oeaw.ac.at">Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)</a><br/>
         Dr. Ignaz Seipel-Platz 2, 1010 Wien, Österreich<br/>
-        E-Mail: <a href="mailto:acdh-tech@oeaw.ac.at" style="color:black">acdh-tech@oeaw.ac.at</a>
+        E-Mail: <a href="mailto:acdh-tech@oeaw.ac.at">acdh-tech@oeaw.ac.at</a>
     </p>
     <p>
       {responsiblePersons}

--- a/api/data/en.html
+++ b/api/data/en.html
@@ -2,7 +2,7 @@
     <h2>Legal disclosure according to §§ 24, 25 Austrian media law and § 5 E-Commerce law:</h2>
     <h3>Media owner, publisher, responsible for content and editorial office, service provider:</h3>
     <p>
-        <a href="https://www.oeaw.ac.at">Austrian Academy of Sciences</a><br/>
+        <a href="https://www.oeaw.ac.at/en/">Austrian Academy of Sciences</a><br/>
         Corporate body organized under public law (BGBl 569/1921 idF BGBl I 130/2003)<br/>
         <a href="https://acdh.oeaw.ac.at">Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)</a><br/>
         Dr. Ignaz Seipel-Platz 2, 1010 Vienna, Austria<br/>
@@ -22,7 +22,7 @@
         President: Univ.-Prof. Dr. Anton Zeilinger<br/>
         Vice president: Univ.-Doz. Dr. phil. Michael Alram<br/>
         Class presidents: Univ.-Prof. Dr. phil. Oliver Jens Schmitt, Univ.-Prof. Dipl.-Ing. Dr.techn. Georg Brasseur<br/>
-        Supervisory body:  Academy council. For more information, please visit <a href="https://www.oeaw.ac.at/oeaw/gremien/akademierat/">https://www.oeaw.ac.at/oeaw/gremien/akademierat/</a>
+        Supervisory body:  Academy council. For more information, please visit <a href="https://www.oeaw.ac.at/en/oeaw/bodies/academy-council/">https://www.oeaw.ac.at/en/oeaw/bodies/academy-council/</a>
 
     </p>
     <h3>Main aim:</h3>
@@ -39,7 +39,7 @@
     <h3>Data privacy notice:</h3>
     <p>{matomoNotice}<br/>
         By using this website, you agree to the manner and purposes of data processing. You can disable cookies in your browser settings. However, this might limit functionality of this website.<br/>
-        Please find the ÖAW's detailed data privacy statement <a href="https://www.oeaw.ac.at/en/oeaw/data-protection/">here</a>.
+        Please find the OEAW's detailed data privacy statement <a href="https://www.oeaw.ac.at/en/oeaw/data-protection/">here</a>.
         The contact data published in the context of the imprint duty may not be used to send promotional or informational material not explicitly requested. We explicitly disagree with this usage.
     </p>
 </div>

--- a/api/data/en.html
+++ b/api/data/en.html
@@ -39,7 +39,7 @@
     <h3>Data privacy notice:</h3>
     <p>{matomoNotice}<br/>
         By using this website, you agree to the manner and purposes of data processing. You can disable cookies in your browser settings. However, this might limit functionality of this website.<br/>
-        Please find the ÖAW's detailed data privacy statement <a href="https://www.oeaw.ac.at/die-oeaw/datenschutz/">here</a>.
+        Please find the ÖAW's detailed data privacy statement <a href="https://www.oeaw.ac.at/en/oeaw/data-protection/">here</a>.
         The contact data published in the context of the imprint duty may not be used to send promotional or informational material not explicitly requested. We explicitly disagree with this usage.
     </p>
 </div>


### PR DESCRIPTION
use english version of oeaw privacy statement on en imprint page.

also, remove inline styles, which should have been removed already by https://github.com/acdh-oeaw/acdh-common-assets/pull/5/commits/e7ff73b5c614529fe257247d4ea8eae5db3f7846